### PR TITLE
Change log path to be in the storage directory.

### DIFF
--- a/src/HynMe/Webserver/Generators/Webserver/Apache.php
+++ b/src/HynMe/Webserver/Generators/Webserver/Apache.php
@@ -15,7 +15,7 @@ class Apache extends AbstractFileGenerator
         return view('webserver::webserver.apache.configuration', [
             'website' => $this->website,
             'public_path' => public_path(),
-            'log_path' => base_path("log/apache-{$this->website->id}-{$this->website->identifier}"),
+            'log_path' => storage_path("logs/apache-{$this->website->id}-{$this->website->identifier}"),
             'base_path' => base_path(),
             'config' => Config::get('webserver.apache')
         ]);

--- a/src/HynMe/Webserver/Generators/Webserver/Nginx.php
+++ b/src/HynMe/Webserver/Generators/Webserver/Nginx.php
@@ -15,7 +15,7 @@ class Nginx extends AbstractFileGenerator
         return view('webserver::webserver.nginx.configuration', [
             'website' => $this->website,
             'public_path' => public_path(),
-            'log_path' => base_path("log/nginx-{$this->website->id}-{$this->website->identifier}"),
+            'log_path' => storage_path("logs/nginx-{$this->website->id}-{$this->website->identifier}"),
             'config' => Config::get('webserver.nginx'),
             'fpm_port' => Config::get('webserver.fpm.port')
         ]);


### PR DESCRIPTION
The base_path('log/...') directory doesn't exist (which also causes nginx not to restart anymore).
Laravel writes its' logs to storage/logs, so I think it would make sense to store the tenant log files there as well.
