### PR TITLE
Changed order of adduser parameters and fixed typo

### DIFF
--- a/src/HynMe/Webserver/Generators/Unix/WebsiteUser.php
+++ b/src/HynMe/Webserver/Generators/Unix/WebsiteUser.php
@@ -30,8 +30,8 @@ class WebsiteUser extends AbstractUserGenerator
         if ($this->name()) {
             return exec(sprintf('adduser %s --home %s --ingroup %s --no-create-home --disabled-password --disabled-login --gecos ""',
                 $this->name(),
-                config('webserver.group'),
-                base_path()));
+                base_path(),
+                config('webserver.group')));
         }
     }
 
@@ -64,7 +64,7 @@ class WebsiteUser extends AbstractUserGenerator
      */
     public function name()
     {
-        return $this->website->wesiteUser;
+        return $this->website->websiteUser;
     }
 
     /**


### PR DESCRIPTION
The order of the parameters in the adduser sprintf commando did not match the parameters that were passed in. This resulted in an error that the home path was wrong.

I also fixed a typo in getting the websiteUser name. Before fixing the typo the WebsiteUser onCreate() would never pass the `if ($this->name())` check, so wouldn't create a unix user.
